### PR TITLE
Modernize local development stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM ubuntu:18.04
+FROM python:3.11-slim
 
-WORKDIR /usr/src/app
-COPY install-packages.sh .
-RUN ./install-packages.sh
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
-COPY setup.py .
-RUN pip3.6 install -e .
-COPY adaero adaero
-COPY gunicorn_starter.sh .
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /opt/app-root/src
+
+COPY install-packages.sh ./
+RUN ./install-packages.sh && rm install-packages.sh
+
+COPY . ./
+RUN pip install --upgrade pip setuptools wheel \
+    && pip install -e .[postgres]
 
 EXPOSE 8080
 ENTRYPOINT ["./gunicorn_starter.sh"]

--- a/README.md
+++ b/README.md
@@ -19,26 +19,21 @@ The following steps were run on a minimal install of Ubuntu LTS 18.04.4
 
 0. Ensure you have the pre-requisites installed
    ```
-   sudo apt install docker.io python3 python3-pip curl
-   sudo curl -L "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-   sudo chmod +x /usr/local/bin/docker-compose
+   sudo apt install docker.io docker-compose-plugin python3 python3-venv
    ```
-1. Build and Run the application on local Docker
+1. Build and run the application with Docker Compose
    ```
-   cd frontend
-   sudo docker build -t adaero-dev-frontend . 
-   cd ..
-   sudo docker build -t adaero-app . 
    cd docker/dev
-   docker-compose up -d
+   docker compose up --build -d
    ```
 
-2. Setup a dummy template, 3 question and period data to carry out a feedback cycle.
+2. Set up demo data (from the repository root)
    ```
    cd ../..
-   sudo pip3 install -e .
-   sudo pip3 install pytest faker freezegun webtest mock 
-   python3 tests/scripts/configure_db.py --config host_example.ini add-test-periods
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -e .[test]
+   python tests/scripts/configure_db.py --config host_example.ini add-test-periods
    ```
 
 3. Once fully started, open http://localhost:4200. The table below shows the users 
@@ -65,10 +60,10 @@ The following steps were run on a minimal install of Ubuntu LTS 18.04.4
 6. Use the following commands to change phases.
 
    ```
-   python3 tests/scripts/configure_db.py --config host_example.ini --subperiod enrollment adjust
-   python3 tests/scripts/configure_db.py --config host_example.ini --subperiod entry adjust
-   python3 tests/scripts/configure_db.py --config host_example.ini --subperiod approval adjust
-   python3 tests/scripts/configure_db.py --config host_example.ini --subperiod review adjust
+   python tests/scripts/configure_db.py --config host_example.ini --subperiod enrollment adjust
+   python tests/scripts/configure_db.py --config host_example.ini --subperiod entry adjust
+   python tests/scripts/configure_db.py --config host_example.ini --subperiod approval adjust
+   python tests/scripts/configure_db.py --config host_example.ini --subperiod review adjust
    ```
    
 7. For a more comprehensive guide, please see the [user guide](/docs/user-guide.pdf)

--- a/adaero/models/__init__.py
+++ b/adaero/models/__init__.py
@@ -66,7 +66,6 @@ def _get_sqlite_engine(filepath):
 def get_session_factory(engine):
     return sessionmaker(
         bind=engine,
-        extension=zope.sqlalchemy.ZopeTransactionExtension(),
         expire_on_commit=False,
     )
 

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,6 +1,8 @@
 version: '2.4'
 services:
   webserver:
+    build:
+      context: ../../frontend
     image: adaero-dev-frontend:latest
     volumes:
       - ../../frontend/src:/opt/app-root/src/src
@@ -18,7 +20,8 @@ services:
     logging:
       driver: "none"
   webapp:
-    image: adaero-app:latest
+    build:
+      context: ../..
     networks:
       - web
       - db

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:10
+FROM node:14-bullseye
 
 # Create app directory
-WORKDIR /usr/src/app
+WORKDIR /opt/app-root/src
 
 # Install app dependencies
 # A wildcard is used to ensure both package.json AND package-lock.json are copied

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10184,9 +10184,9 @@
       "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
     },
     "node-sass": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
-      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
+      "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "bootstrap": "^4.3.0",
     "core-js": "^2.6.11",
     "jquery": "^1.9.1",
-    "node-sass": "^4.13.1",
+    "node-sass": "^4.14.1",
     "popper.js": "^1.16.1",
     "rxjs": "^6.5.5",
     "tslib": "^1.10.0",

--- a/install-packages.sh
+++ b/install-packages.sh
@@ -16,12 +16,19 @@ apt-get update
 # Install security updates:
 apt-get -y upgrade
 
-# Install a new package, without unnecessary recommended packages:
+# Install build and runtime dependencies required by the Python stack:
 apt-get -y install --no-install-recommends \
-  python3.6 curl ca-certificates \
-  autoconf build-essential \
-  libxml2-dev libxslt-dev python3-dev \
-  libldap2-dev libsasl2-dev slapd ldap-utils
+  build-essential \
+  ca-certificates \
+  curl \
+  gcc \
+  libffi-dev \
+  libldap2-dev \
+  libpq-dev \
+  libsasl2-dev \
+  libssl-dev \
+  libxml2-dev \
+  libxslt-dev
 
 # Delete cached files we don't need anymore:
 apt-get clean

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,15 @@ setup(
     # Choose your license
     license='AGPL 3.0',
 
+    python_requires='>=3.9',
+
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 4 - Beta',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     # What does your project relate to?
@@ -57,29 +60,29 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'pyramid',
-        'pyramid-beaker',
-        'waitress',
-        'python-ldap',
-        'pyramid_tm',
-        'SQLAlchemy',
-        'transaction',
-        'zope.sqlalchemy==1.1',
-        'pycrypto',
-        'rest_toolkit',
-        'python-dateutil',
-        'apscheduler',
-        'Paste',
-        'beautifulsoup4',
-        'lxml',
-        'pytz',
-        'alembic',
-        'unicodecsv',
-        'jinja2',
-        'click',
-        'pandas',
-        'gunicorn',
-        'psycopg2-binary'
+        'alembic>=1.12,<2',
+        'apscheduler>=3.10,<4',
+        'beautifulsoup4>=4.10,<5',
+        'click>=8.1,<9',
+        'gunicorn>=21,<22',
+        'jinja2>=3,<4',
+        'lxml>=4.9,<5',
+        'pandas>=1.5,<3',
+        'Paste>=3.10,<4',
+        'psycopg2-binary>=2.9,<3',
+        'pyramid>=2.0,<3',
+        'pyramid-beaker>=0.9,<1',
+        'pyramid_tm>=2.6,<3',
+        'python-dateutil>=2.8,<3',
+        'python-ldap>=3.4,<4',
+        'pytz>=2023.3',
+        'rest_toolkit>=0.17,<0.18',
+        'SQLAlchemy>=1.4,<2',
+        'transaction>=3,<4',
+        'unicodecsv>=0.14,<0.15',
+        'waitress>=2.1,<3',
+        'zope.sqlalchemy>=1.6,<2',
+        'pycryptodome>=3.18,<4'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
## Summary
- update backend Docker image and dependency pins to run on Python 3.11 with maintained libraries and pycryptodome
- refresh docker-compose workflow and documentation so developers can launch services with docker compose and a local virtualenv
- bump frontend tooling to Node 14 with node-sass 4.14.1 so the Angular dev server starts on modern hosts

## Testing
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68e25746337883298e6750128a1ad4d1